### PR TITLE
Auto nonce management

### DIFF
--- a/src/main/java/tech/pegasys/net/txapigw/model/Transaction.java
+++ b/src/main/java/tech/pegasys/net/txapigw/model/Transaction.java
@@ -20,7 +20,7 @@ import lombok.ToString;
 @AllArgsConstructor
 @Builder
 public class Transaction {
-  @NotNull private BigInteger nonce;
+  private BigInteger nonce;
 
   @Schema(
       example = "0x61aCB88dA0DBA1A43592f7cc548b3319Fa615e1b",

--- a/src/main/java/tech/pegasys/net/txapigw/service/TransactionService.java
+++ b/src/main/java/tech/pegasys/net/txapigw/service/TransactionService.java
@@ -5,7 +5,11 @@ import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.web3j.crypto.Credentials;
 import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.DefaultBlockParameter;
+import org.web3j.protocol.core.DefaultBlockParameterName;
+import org.web3j.protocol.core.methods.response.EthGetTransactionCount;
 import org.web3j.protocol.core.methods.response.EthSendTransaction;
 import org.web3j.utils.Numeric;
 import tech.pegasys.net.txapigw.api.response.transaction.SubmitTransactionResponse;
@@ -24,6 +28,7 @@ public class TransactionService {
   public SubmitTransactionResponse submit(final String privateKey, final Transaction transaction) {
     try {
       log.info("submit transaction: {}", transaction.toString());
+      prepare(privateKey, transaction);
       final byte[] signedTransaction = signer.sign(privateKey, transaction);
       final EthSendTransaction response =
           web3.ethSendRawTransaction(Numeric.toHexString(signedTransaction)).send();
@@ -39,7 +44,8 @@ public class TransactionService {
       final String privateKey, final EIP1559Transaction transaction) {
     try {
       log.info("submit transaction: {}", transaction.toString());
-      final byte[] signedTransaction = signer.sign(privateKey, transaction);
+      prepare(privateKey, transaction);
+      final byte[] signedTransaction = signer.signEIP1559(privateKey, transaction);
       final EthSendTransaction response =
           web3.ethSendRawTransaction(Numeric.toHexString(signedTransaction)).send();
       log.info("transaction sent: {}", response.getTransactionHash());
@@ -48,5 +54,23 @@ public class TransactionService {
       log.error("cannot submit transaction", e);
       throw new TxApiGwException(ErrorCode.ETHEREUM_CLIENT_ERROR, e);
     }
+  }
+
+  public void prepare(final String privateKey, final Transaction transaction) throws IOException {
+    if (transaction.getNonce() == null || transaction.getNonce().signum() == -1) {
+      setAutoNonce(privateKey, transaction);
+    }
+  }
+
+  public void setAutoNonce(final String privateKey, final Transaction transaction)
+      throws IOException {
+    final String address = Credentials.create(privateKey).getAddress();
+    log.info("retrieving nonce for address {}", address);
+    final EthGetTransactionCount getTransactionCountResponse =
+        web3.ethGetTransactionCount(
+                address, DefaultBlockParameter.valueOf(DefaultBlockParameterName.LATEST.getValue()))
+            .send();
+    transaction.setNonce(getTransactionCountResponse.getTransactionCount());
+    log.info("transaction nonce auto set to {} for address {}", transaction.getNonce(), address);
   }
 }

--- a/src/main/java/tech/pegasys/net/txapigw/service/TransactionSigner.java
+++ b/src/main/java/tech/pegasys/net/txapigw/service/TransactionSigner.java
@@ -21,7 +21,7 @@ public class TransactionSigner {
     return TransactionEncoder.signMessage(etherTransaction, Credentials.create(privateKey));
   }
 
-  public byte[] sign(final String privateKey, final EIP1559Transaction transaction) {
+  public byte[] signEIP1559(final String privateKey, final EIP1559Transaction transaction) {
     final RawTransaction etherTransaction =
         RawTransaction.createEtherTransaction(
             transaction.getNonce(),

--- a/src/test/java/tech/pegasys/net/txapigw/controller/transaction/TxControllerTest.java
+++ b/src/test/java/tech/pegasys/net/txapigw/controller/transaction/TxControllerTest.java
@@ -69,7 +69,7 @@ public class TxControllerTest {
                 .content("{\"unknownField\": 1}")
                 .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().is(HttpStatus.BAD_REQUEST.value()))
-        .andExpect(jsonPath("$.nonce", is("must not be null")));
+        .andExpect(jsonPath("$.gasLimit", is("must not be null")));
   }
 
   @Test
@@ -102,7 +102,7 @@ public class TxControllerTest {
                 .content("{\"unknownField\": 1}")
                 .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().is(HttpStatus.BAD_REQUEST.value()))
-        .andExpect(jsonPath("$.nonce", is("must not be null")));
+        .andExpect(jsonPath("$.minerBribe", is("must not be null")));
   }
 
   public static String asJsonString(final Object obj) {

--- a/src/test/java/tech/pegasys/net/txapigw/service/TransactionSignerTest.java
+++ b/src/test/java/tech/pegasys/net/txapigw/service/TransactionSignerTest.java
@@ -33,7 +33,7 @@ public class TransactionSignerTest {
   @Test
   public void givenEIP1559Transaction_whenSign_thenReturnCorrectByteArray() {
     assertThat(
-            signer.sign(
+            signer.signEIP1559(
                 PRIVATE_KEY,
                 EIP1559Transaction.eip1559Builder()
                     .nonce(BigInteger.ONE)


### PR DESCRIPTION
## Description

As a user i would like to be able to submit a transaction without setting the nonce.
In that case the service should automatically query the ethereum client to retrieve the next nonce to use.
This feature should be available for frontier and EIP-1559 transactions.

fixes #1 
Signed-off-by: Abdelhamid Bakhta <abdelhamid.bakhta@consensys.net>